### PR TITLE
Minor changes to code in SFApp and SFAsset to address compile warnings

### DIFF
--- a/src/SFApp.cpp
+++ b/src/SFApp.cpp
@@ -51,10 +51,12 @@ void SFApp::OnEvent(SFEvent& event) {
     fire ++;
     FireProjectile();
     break;
+  default:
+    break;
   }
 }
 
-int SFApp::OnExecute() {
+void SFApp::OnExecute() {
   // Execute the app
   SDL_Event event;
   while (SDL_WaitEvent(&event) && is_running) {

--- a/src/SFApp.h
+++ b/src/SFApp.h
@@ -22,7 +22,7 @@ public:
   SFApp(std::shared_ptr<SFWindow>);
   virtual ~SFApp();
   void    OnEvent(SFEvent &);
-  int     OnExecute();
+  void    OnExecute();
   void    OnUpdateWorld();
   void    OnRender();
 

--- a/src/SFAsset.cpp
+++ b/src/SFAsset.cpp
@@ -18,6 +18,8 @@ SFAsset::SFAsset(SFASSETTYPE type, std::shared_ptr<SFWindow> window): type(type)
   case SFASSET_COIN:
     sprite = IMG_LoadTexture(sf_window->getRenderer(), "assets/coin.png");
     break;
+  default:
+    break;
   }
 
   if(!sprite) {


### PR DESCRIPTION
Some small tweaks to the code to remove warnings that appear on compile.
- `SFApp::OnExecute()` defined as `int`, but used as `void`
- switch statements in SFApp and SFAsset were missing `default:`
